### PR TITLE
feat: Añadir funcionalidad de inicio de sesión con Google con Allauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+
+#Keys
+key_google.json

--- a/autenticacion/templates/login.html
+++ b/autenticacion/templates/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Autenticación con Google</title>
+</head>
+<body>
+    {% load socialaccount %}
+    <h2>Google login</h2>
+    <a href="{% provider_login_url 'google' %}?next=/api_autenticacion/login">Login con Google</a>
+
+
+    {% if user.is_authenticated %}
+        <p>Usuario autenticado: {{ user.nombre_usuario }}</p>
+        <a href="{% url 'logout' %}">Cerrar sesión</a>
+    {% endif %}
+</body>
+</html>

--- a/autenticacion/urls.py
+++ b/autenticacion/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('login/', views.login_view, name='login'),
+    path('logout/', views.logout_view, name='logout'),
+]

--- a/autenticacion/views.py
+++ b/autenticacion/views.py
@@ -1,3 +1,12 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.contrib.auth import logout
 
 # Create your views here.
+from django.shortcuts import render
+
+def login_view(request):
+    return render(request, 'login.html')
+
+def logout_view(request):
+    logout(request)
+    return redirect('login')

--- a/dizcover_back/settings.py
+++ b/dizcover_back/settings.py
@@ -30,6 +30,8 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
+SITE_ID = 2
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -46,7 +48,29 @@ INSTALLED_APPS = [
     'autenticacion',
     # AGREGANDO DJANGO REST FRAMEWORK
     'rest_framework',
+    #AUTENTICACION CON GOOGLE
+    'django.contrib.sites',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
+    
 ]
+
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': [
+            'profile',
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        }
+    }
+        
+}
+
+
 # Cambiando el modelo de usuario por defecto
 AUTH_USER_MODEL = 'autenticacion.Users'
 
@@ -58,6 +82,9 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # Add the account middleware:
+    "allauth.account.middleware.AccountMiddleware",
 ]
 
 ROOT_URLCONF = 'dizcover_back.urls'
@@ -77,6 +104,8 @@ TEMPLATES = [
         },
     },
 ]
+
+
 
 WSGI_APPLICATION = 'dizcover_back.wsgi.application'
 
@@ -137,3 +166,18 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }
+
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+)
+
+LOGIN_REDIRECT_URL = '/api_autenticacion/login'
+LOGOUT_REDIRECT_URL = '/api_autenticacion/login'
+ACCOUNT_USER_MODEL_USERNAME_FIELD = 'nombre_usuario'
+ACCOUNT_USERNAME_REQUIRED = True  # Cambia a False si no quieres usar nombre_usuario
+ACCOUNT_AUTHENTICATION_METHOD = 'username'  # Puede ser 'email' si prefieres autenticación por correo
+ACCOUNT_EMAIL_REQUIRED = True  # True si el email es obligatorio
+ACCOUNT_UNIQUE_EMAIL = True
+

--- a/dizcover_back/urls.py
+++ b/dizcover_back/urls.py
@@ -25,4 +25,6 @@ urlpatterns = [
     path('api_establecimientos/', include('establecimiento.urls')),
     path('api_fiestero/', include('fiestero.urls')),
     path('docs/', include_docs_urls(title='Dizcover API Documentation')),
+    path('api_autenticacion/', include('autenticacion.urls')), #Para la autenticacion
+    path('accounts/', include('allauth.urls')), #Para la autenticacion con google
 ]


### PR DESCRIPTION
- Añadir plantilla login.html para el inicio de sesión con Google (esto es de prueba)
- Implementar funciones login_view y logout_view en views.py
- Añadir URLs de login y logout en autenticacion/urls.py
- Actualizar settings.py para incluir los paquetes y configuraciones necesarias para la autenticación de Google
NOTA: debes instalar las siguientes dependencias: cryptography, PyJWT y django-allauth